### PR TITLE
Add Privacy and Terms pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,8 @@ import "./App.css";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import LandingPage from "./pages/LandingPage";
 import AdminDashboard from "./pages/AdminDashboard";
+import PrivacyPolicy from "./pages/PrivacyPolicy";
+import TermsOfService from "./pages/TermsOfService";
 import { Toaster } from "./components/ui/toaster";
 import GoogleAnalytics from "./components/GoogleAnalytics";
 
@@ -14,6 +16,8 @@ function App() {
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/admin" element={<AdminDashboard />} />
+          <Route path="/privacy" element={<PrivacyPolicy />} />
+          <Route path="/terms" element={<TermsOfService />} />
         </Routes>
       </BrowserRouter>
       <Toaster />

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -457,13 +457,13 @@ const LandingPage = () => {
                 Admin Dashboard
               </a>
               <span className="text-gray-600">|</span>
-              <span className="text-gray-400 text-sm">
+              <a href="/privacy" className="text-gray-400 hover:text-white text-sm">
                 Privacy Policy
-              </span>
+              </a>
               <span className="text-gray-600">|</span>
-              <span className="text-gray-400 text-sm">
+              <a href="/terms" className="text-gray-400 hover:text-white text-sm">
                 Terms of Service
-              </span>
+              </a>
             </div>
             <p className="text-gray-400 text-sm">
               © 2025 Decloak.ai. Your privacy is our priority.

--- a/src/pages/PrivacyPolicy.jsx
+++ b/src/pages/PrivacyPolicy.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const PrivacyPolicy = () => (
+  <div className="max-w-3xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
+    <h1 className="text-3xl font-bold mb-4">Privacy Policy</h1>
+    <p className="mb-4">
+      Decloak.ai values your privacy. This page describes how we handle your
+      personal information when you use our services. We only collect the data
+      necessary to provide and improve our products. We never sell your
+      personal data.
+    </p>
+    <p>
+      By using Decloak.ai, you agree to this policy. If you have any questions
+      or concerns, please contact us at support@decloak.ai.
+    </p>
+  </div>
+);
+
+export default PrivacyPolicy;

--- a/src/pages/TermsOfService.jsx
+++ b/src/pages/TermsOfService.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const TermsOfService = () => (
+  <div className="max-w-3xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
+    <h1 className="text-3xl font-bold mb-4">Terms of Service</h1>
+    <p className="mb-4">
+      These terms govern your use of Decloak.ai. By accessing or using our
+      website, you agree to be bound by them. You may not use our services for
+      any unlawful purpose, and we reserve the right to terminate accounts that
+      violate these terms.
+    </p>
+    <p>
+      We may update these terms occasionally. Continued use of Decloak.ai after
+      changes become effective constitutes acceptance of the revised terms.
+    </p>
+  </div>
+);
+
+export default TermsOfService;


### PR DESCRIPTION
## Summary
- add simple `PrivacyPolicy` and `TermsOfService` pages
- register new routes in `App.js`
- link footer to the new pages

## Testing
- `yarn test` *(fails: could not download yarn packages)*

------
https://chatgpt.com/codex/tasks/task_e_687b1d333e60832c9fd7b6f4157651c9