### PR TITLE
Fix useTheme hook SSR safety

### DIFF
--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -2,17 +2,19 @@ import { useState, useEffect } from 'react';
 
 export const useTheme = () => {
   const [theme, setTheme] = useState(() => {
-    // Check if there's a saved theme in localStorage
-    const savedTheme = localStorage.getItem('decloak-theme');
-    if (savedTheme) {
-      return savedTheme;
+    if (typeof window !== 'undefined') {
+      // Check if there's a saved theme in localStorage
+      const savedTheme = window.localStorage.getItem('decloak-theme');
+      if (savedTheme) {
+        return savedTheme;
+      }
+
+      // Check system preference
+      if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        return 'dark';
+      }
     }
-    
-    // Check system preference
-    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      return 'dark';
-    }
-    
+
     return 'light';
   });
 


### PR DESCRIPTION
## Summary
- guard `localStorage` access when computing initial theme

## Testing
- `yarn install`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687b27fb6bac832c974ee0adafa005c2