### PR TITLE
Add privacy and terms pages with SEO meta

### DIFF
--- a/pages/admin.jsx
+++ b/pages/admin.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 
@@ -18,5 +19,17 @@ export default function AdminPage() {
   }, [router]);
 
   if (!allowed) return null;
-  return <AdminDashboard />;
+  return (
+    <>
+      <Head>
+        <title>Admin Dashboard - Decloak.ai</title>
+        <meta
+          name="description"
+          content="Administrative dashboard for managing Decloak.ai"
+        />
+        <meta name="keywords" content="decloak admin dashboard" />
+      </Head>
+      <AdminDashboard />
+    </>
+  );
 }

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,5 +1,21 @@
+import Head from 'next/head';
 import LandingPage from '../src/pages/LandingPage';
 
 export default function Home() {
-  return <LandingPage />;
+  return (
+    <>
+      <Head>
+        <title>Decloak.ai - AI-Powered Privacy Control</title>
+        <meta
+          name="description"
+          content="Decloak.ai continuously scans the internet for leaked personal data and helps you remove it."
+        />
+        <meta
+          name="keywords"
+          content="privacy, data leak monitoring, dark web, digital footprint, decloak"
+        />
+      </Head>
+      <LandingPage />
+    </>
+  );
 }

--- a/pages/login.jsx
+++ b/pages/login.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useTheme } from '../src/hooks/useTheme';
 import { Input } from '../src/components/ui/input';
@@ -21,11 +22,20 @@ export default function LoginPage() {
     }
   };
   return (
-    <div className={`min-h-screen ${theme === 'dark' ? 'dark' : ''}`}>
-      <div className="min-h-screen flex items-center justify-center bg-background transition-colors duration-300 p-4">
-        <form onSubmit={handleSubmit} className="bg-card p-6 rounded-lg shadow w-full max-w-sm space-y-4">
-          <div className="flex justify-between items-center">
-            <h1 className="text-lg font-semibold text-foreground">Admin Login</h1>
+    <>
+      <Head>
+        <title>Admin Login - Decloak.ai</title>
+        <meta
+          name="description"
+          content="Secure administrator login for Decloak.ai"
+        />
+        <meta name="keywords" content="decloak admin login" />
+      </Head>
+      <div className={`min-h-screen ${theme === 'dark' ? 'dark' : ''}`}>
+        <div className="min-h-screen flex items-center justify-center bg-background transition-colors duration-300 p-4">
+          <form onSubmit={handleSubmit} className="bg-card p-6 rounded-lg shadow w-full max-w-sm space-y-4">
+            <div className="flex justify-between items-center">
+              <h1 className="text-lg font-semibold text-foreground">Admin Login</h1>
             <Button type="button" variant="ghost" size="icon" onClick={toggleTheme} className="w-9 h-9">
               {theme === 'dark' ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
             </Button>
@@ -33,7 +43,8 @@ export default function LoginPage() {
           <Input type="password" placeholder="Password" value={password} onChange={(e)=>setPassword(e.target.value)} />
           <Button type="submit" className="w-full">Login</Button>
         </form>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/pages/privacy.jsx
+++ b/pages/privacy.jsx
@@ -1,0 +1,35 @@
+import Head from 'next/head';
+import { useTheme } from '../src/hooks/useTheme';
+import { Button } from '../src/components/ui/button';
+import { Sun, Moon } from 'lucide-react';
+
+export default function PrivacyPage() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <>
+      <Head>
+        <title>Privacy Policy - Decloak.ai</title>
+        <meta
+          name="description"
+          content="Learn how Decloak.ai protects and uses your data."
+        />
+        <meta name="keywords" content="decloak privacy policy" />
+      </Head>
+      <div className={`min-h-screen ${theme === 'dark' ? 'dark' : ''}`}>
+        <div className="min-h-screen bg-background transition-colors duration-300 p-6">
+          <div className="max-w-3xl mx-auto space-y-6 text-foreground">
+            <div className="flex justify-between items-center">
+              <h1 className="text-2xl font-semibold">Privacy Policy</h1>
+              <Button type="button" variant="ghost" size="icon" onClick={toggleTheme} className="w-9 h-9">
+                {theme === 'dark' ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+              </Button>
+            </div>
+            <p>
+              This page outlines how Decloak.ai collects, uses and stores personal information. We value your privacy and only use your data to provide our services.
+            </p>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/pages/terms.jsx
+++ b/pages/terms.jsx
@@ -1,0 +1,35 @@
+import Head from 'next/head';
+import { useTheme } from '../src/hooks/useTheme';
+import { Button } from '../src/components/ui/button';
+import { Sun, Moon } from 'lucide-react';
+
+export default function TermsPage() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <>
+      <Head>
+        <title>Terms of Service - Decloak.ai</title>
+        <meta
+          name="description"
+          content="Read the terms and conditions for using Decloak.ai services."
+        />
+        <meta name="keywords" content="decloak terms of service" />
+      </Head>
+      <div className={`min-h-screen ${theme === 'dark' ? 'dark' : ''}`}>
+        <div className="min-h-screen bg-background transition-colors duration-300 p-6">
+          <div className="max-w-3xl mx-auto space-y-6 text-foreground">
+            <div className="flex justify-between items-center">
+              <h1 className="text-2xl font-semibold">Terms of Service</h1>
+              <Button type="button" variant="ghost" size="icon" onClick={toggleTheme} className="w-9 h-9">
+                {theme === 'dark' ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+              </Button>
+            </div>
+            <p>
+              By using Decloak.ai you agree to the following terms and conditions. This summary is provided for demonstration purposes.
+            </p>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -457,13 +457,13 @@ const LandingPage = () => {
                 Admin Dashboard
               </a>
               <span className="text-gray-600">|</span>
-              <span className="text-gray-400 text-sm">
+              <a href="/privacy" className="text-gray-400 hover:text-white text-sm">
                 Privacy Policy
-              </span>
+              </a>
               <span className="text-gray-600">|</span>
-              <span className="text-gray-400 text-sm">
+              <a href="/terms" className="text-gray-400 hover:text-white text-sm">
                 Terms of Service
-              </span>
+              </a>
             </div>
             <p className="text-gray-400 text-sm">
               © 2025 Decloak.ai. Your privacy is our priority.


### PR DESCRIPTION
## Summary
- add metadata to all pages
- add dark-themed Privacy Policy and Terms of Service pages
- link new pages in landing page footer

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b2db8b194832c83f608ced3ee2a1a