### PR TITLE
Add temporary email detection on sign-up

### DIFF
--- a/src/lib/emailUtils.js
+++ b/src/lib/emailUtils.js
@@ -1,0 +1,14 @@
+export async function isDisposableEmail(email) {
+  if (!email || !email.includes('@')) return false;
+  const domain = email.split('@').pop().toLowerCase();
+
+  try {
+    const res = await fetch(`https://open.kickbox.com/v1/disposable/${domain}`);
+    if (!res.ok) return false;
+    const data = await res.json();
+    return data.disposable === true;
+  } catch (err) {
+    console.error('Disposable email check failed:', err);
+    return false;
+  }
+}

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -9,6 +9,7 @@ import { useTheme } from '../hooks/useTheme';
 import { trackSignup, trackEvent } from '../components/GoogleAnalytics';
 import CountdownTimer from '../components/CountdownTimer';
 import axios from 'axios';
+import { isDisposableEmail } from '../lib/emailUtils';
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
 const API = `${BACKEND_URL}/api`;
@@ -138,6 +139,15 @@ const LandingPage = () => {
       toast({
         title: "Email Required",
         description: "Please enter your email address to request access.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (await isDisposableEmail(email)) {
+      toast({
+        title: "Temporary Email Detected",
+        description: "Please use a permanent email address to request access.",
         variant: "destructive",
       });
       return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1641,6 +1641,7 @@ didyoumean@^1.2.2:
   resolved "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz"
   integrity sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==
 
+
 dlv@^1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz"


### PR DESCRIPTION
## Summary
- remove `disposable-email-domains` dependency
- check disposable emails via Kickbox API
- await disposable check in LandingPage

## Testing
- `yarn install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e76401f6c832cb8dd6b1270f14cd9